### PR TITLE
feat: /score 포트폴리오+페르소나 기반 실제 유사도 계산

### DIFF
--- a/app/domain/stock_analyze/dto.py
+++ b/app/domain/stock_analyze/dto.py
@@ -12,6 +12,18 @@ class ReportStreamRequest(BaseModel):
     composite_score: float
 
 
+class PortfolioStock(BaseModel):
+    """스코어링 시 유사도 계산용 보유 종목 정보"""
+    stock_code: str
+    market_cap: float
+    per: float
+    pbr: float
+    roe: float
+    debt_ratio: float
+    dividend_yield: float
+    investment_amount: float
+
+
 class StockAnalyzeRequest(BaseModel):
     """Spring 서버와의 연동을 위해 영문 필드명 사용 (한글도 alias로 지원)"""
 
@@ -22,6 +34,10 @@ class StockAnalyzeRequest(BaseModel):
     roe: float = Field(..., alias="ROE")
     debt_ratio: float = Field(..., alias="부채비율")
     dividend_yield: float = Field(..., alias="배당수익률")
+
+    # 유사도 계산용 (Optional — 없으면 기존처럼 50.0 사용)
+    portfolio_stocks: Optional[List[PortfolioStock]] = None
+    persona: Optional[str] = None
 
     class Config:
         populate_by_name = True  # 한글 필드명과 영문 필드명 둘 다 허용

--- a/app/domain/stock_analyze/service.py
+++ b/app/domain/stock_analyze/service.py
@@ -68,9 +68,14 @@ def get_redis_client():
 
 
 def generate_cache_key(request: StockAnalyzeRequest) -> str:
-    """요청 데이터로 캐시 키 생성 (재무 지표 변경 시 다른 캐시)"""
-    # 단축코드와 재무 지표들을 조합하여 고유한 해시 생성
+    """요청 데이터로 캐시 키 생성 (재무 지표 + 포트폴리오 + 페르소나 포함)"""
     data_str = f"{request.stock_code}:{request.market_cap}:{request.per}:{request.pbr}:{request.roe}:{request.debt_ratio}:{request.dividend_yield}"
+    # 포트폴리오 + 페르소나가 있으면 캐시 키에 포함 (다른 유저 = 다른 캐시)
+    if request.portfolio_stocks:
+        portfolio_str = ",".join(f"{s.stock_code}:{s.investment_amount}" for s in request.portfolio_stocks)
+        data_str += f":{portfolio_str}"
+    if request.persona:
+        data_str += f":{request.persona}"
     hash_key = hashlib.md5(data_str.encode()).hexdigest()
     return f"stock_analyze:{hash_key}"
 

--- a/app/domain/stock_analyze/service.py
+++ b/app/domain/stock_analyze/service.py
@@ -11,7 +11,8 @@ from numpy.linalg import norm
 from .dto import StockAnalyzeRequest, StockAnalyzeResponse
 from app.ai_models.scoring import (
     growth_score, stability_score, composite_score, DEFAULT_WEIGHTS,
-    score_all_stocks, compute_user_feature_vector,
+    PERSONA_WEIGHTS, score_all_stocks, compute_user_feature_vector,
+    cosine_similarity as cos_sim, cosine_similarity_to_score,
 )
 from .recommend_dto import RecommendRequest
 
@@ -198,7 +199,46 @@ def score_stock_only(request: StockAnalyzeRequest, use_cache: bool = True) -> di
 
     g_score = growth_score(roe=request.roe, per=request.per)
     s_score = stability_score(debt_ratio=request.debt_ratio, dividend_yield=request.dividend_yield)
-    c_score = composite_score(50.0, g_score, s_score, DEFAULT_WEIGHTS)
+
+    # 유사도 계산: 포트폴리오가 있으면 실제 계산, 없으면 50.0 (중립)
+    sim_score = 50.0
+    if request.portfolio_stocks and len(request.portfolio_stocks) > 0:
+        try:
+            from app.domain.portfolio_analyze.service import get_portfolio_style_vector
+
+            # 유저 6차원 피처 벡터 (가중평균)
+            stocks_data = [{
+                "market_cap": s.market_cap, "per": s.per, "pbr": s.pbr,
+                "roe": s.roe, "debt_ratio": s.debt_ratio,
+                "dividend_yield": s.dividend_yield,
+                "investment_amount": s.investment_amount,
+            } for s in request.portfolio_stocks]
+            user_feature_vec = compute_user_feature_vector(stocks_data, scaler)
+
+            # 유저 8차원 클러스터 벡터
+            portfolio_df = pd.DataFrame([{
+                "단축코드": s.stock_code, "시가총액": s.market_cap,
+                "per": s.per, "pbr": s.pbr, "ROE": s.roe,
+                "부채비율": s.debt_ratio, "배당수익률": s.dividend_yield,
+                "투자금액": s.investment_amount,
+            } for s in request.portfolio_stocks])
+            user_cluster_vec, _ = get_portfolio_style_vector(portfolio_df)
+
+            # 종목의 클러스터 벡터 (one-hot)
+            stock_cluster_vec = np.zeros(8)
+            stock_cluster_vec[pred_group] = 1.0
+
+            # 2단계 유사도: 피처(70%) + 클러스터(30%)
+            feature_sim = cosine_similarity_to_score(cos_sim(user_feature_vec, scaled[0]))
+            cluster_sim = cosine_similarity_to_score(cos_sim(user_cluster_vec, stock_cluster_vec))
+            sim_score = feature_sim * 0.7 + cluster_sim * 0.3
+        except Exception as e:
+            print(f"유사도 계산 실패 (기본값 50 사용): {e}")
+            sim_score = 50.0
+
+    # 페르소나 가중치 적용
+    weights = PERSONA_WEIGHTS.get(request.persona, DEFAULT_WEIGHTS) if request.persona else DEFAULT_WEIGHTS
+    c_score = composite_score(sim_score, g_score, s_score, weights)
 
     result = {
         "stock_code": request.stock_code,
@@ -210,7 +250,7 @@ def score_stock_only(request: StockAnalyzeRequest, use_cache: bool = True) -> di
         "scores": {
             "growth_score": g_score,
             "stability_score": s_score,
-            "similarity_score": 50.0,
+            "similarity_score": round(sim_score, 2),
             "composite_score": c_score,
         },
     }

--- a/app/infrastructure/gemini_embedding_client.py
+++ b/app/infrastructure/gemini_embedding_client.py
@@ -1,6 +1,6 @@
 """
 Gemini 임베딩 클라이언트
-- text-embedding-004 모델 (768차원)
+- gemini-embedding-001 모델 (3072차원)
 - 배치 임베딩 지원
 """
 
@@ -24,13 +24,13 @@ def _get_client() -> genai.Client:
 
 def embed_text(text: str) -> list[float]:
     """
-    단일 텍스트 임베딩 (768차원)
+    단일 텍스트 임베딩 (3072차원)
 
     Args:
         text: 임베딩할 텍스트
 
     Returns:
-        768차원 float 리스트
+        3072차원 float 리스트
     """
     client = _get_client()
     response = client.models.embed_content(


### PR DESCRIPTION
## 변경 내용

- StockAnalyzeRequest에 portfolio_stocks, persona Optional 필드 추가
- score_stock_only(): 포트폴리오 있으면 2단계 유사도(피처70%+클러스터30%) 실제 계산
- 페르소나별 가중치 적용 (워렌 버핏, 캐시 우드 등)
- 캐시 키에 포트폴리오+페르소나 포함 (다른 유저 = 다른 캐시)
- 하위 호환: body 없이 호출하면 기존처럼 유사도 50.0

## 테스트 결과

| 케이스 | 유사도 | 종합 |
|--------|--------|------|
| 포트폴리오 없음 | 50.0 | 73.37 |
| 포트폴리오 있음 | 97.83 | 92.5 |
| + 워렌 버핏 | 97.83 | 92.27 |
| + 캐시 우드 | 97.83 | 94.66 |
| /recommend와 점수 차이 | - | 0.00 |